### PR TITLE
Use the Operation class directly rather than wrapping in Q

### DIFF
--- a/pgpubsub/listeners.py
+++ b/pgpubsub/listeners.py
@@ -2,7 +2,7 @@ from functools import wraps
 from typing import Union, Type
 
 import pgtrigger
-from pgtrigger import Q, Trigger
+from pgtrigger import Trigger
 
 from pgpubsub.channel import (
     locate_channel,
@@ -26,7 +26,7 @@ def pre_save_listener(channel: Union[Type[TriggerChannel], str]):
     return _trigger_action_listener(
         channel,
         pgtrigger.Before,
-        Q(pgtrigger.Update) | Q(pgtrigger.Insert),
+        pgtrigger.Update | pgtrigger.Insert,
         )
 
 
@@ -34,7 +34,7 @@ def post_save_listener(channel: Union[Type[TriggerChannel], str]):
     return _trigger_action_listener(
         channel,
         pgtrigger.After,
-        Q(pgtrigger.Update) | Q(pgtrigger.Insert),
+        pgtrigger.Update | pgtrigger.Insert,
         )
 
 

--- a/pgpubsub/tests/channels.py
+++ b/pgpubsub/tests/channels.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 import datetime
 
 from pgpubsub.channel import Channel, TriggerChannel
-from pgpubsub.tests.models import Author, Post
+from pgpubsub.tests.models import Author, Media, Post
 
 
 @dataclass
@@ -15,6 +15,12 @@ class Reads(Channel):
 @dataclass
 class PostReads(Reads):
     model_type: str = 'Post'
+
+
+@dataclass
+class MediaTriggerChannel(TriggerChannel):
+    model = Media
+    lock_notifications = True
 
 
 @dataclass

--- a/pgpubsub/tests/listeners.py
+++ b/pgpubsub/tests/listeners.py
@@ -7,10 +7,11 @@ from django.db.transaction import atomic
 import pgpubsub
 from pgpubsub.tests.channels import (
     AuthorTriggerChannel,
+    MediaTriggerChannel,
     PostReads,
     PostTriggerChannel,
 )
-from pgpubsub.tests.models import Author, Post
+from pgpubsub.tests.models import Author, Media, Post
 
 post_reads_per_date_cache = defaultdict(dict)
 author_reads_cache = {}
@@ -55,3 +56,11 @@ def email_author(old: Post, new: Post):
 
 def email(author: Author):
     pass
+
+
+@pgpubsub.post_save_listener(MediaTriggerChannel)
+def scan_media(old: Media, new: Media):
+    if not old:
+        print(f'Perform virus scan on the new media {new}.')
+    else:
+        print(f'Media updated; scan {new} all over again.')


### PR DESCRIPTION
The pgtrigger package requires Operation class to generate the correct SQL.

Add a test to ensure that `post_save_listener` is tested.

Fixes #17 