### PR TITLE
Fixes DateTimeField deserialization from triggers

### DIFF
--- a/pgpubsub/channel.py
+++ b/pgpubsub/channel.py
@@ -10,6 +10,7 @@ from typing import Callable, Dict, Union, List
 
 from django.apps import apps
 from django.db import models
+from django.db.models import fields
 
 
 registry = defaultdict(list)
@@ -146,12 +147,21 @@ class TriggerPayload:
     @property
     def old(self):
         if self._old_row_data:
-            return self._model(**self._old_row_data)
+            return self._entity_from_json(self._model, self._old_row_data)
 
     @property
     def new(self):
         if self._new_row_data:
-            return self._model(**self._new_row_data)
+            return self._entity_from_json(self._model, self._new_row_data)
+
+    def _entity_from_json(self, model, model_payload):
+        data = {}
+        for k, v in model_payload.items():
+            if isinstance(model._meta.get_field(k), fields.DateTimeField):
+                data[k] = datetime.datetime.fromisoformat(v)
+            else:
+                data[k] = v
+        return model(**data)
 
 
 @dataclass

--- a/pgpubsub/triggers.py
+++ b/pgpubsub/triggers.py
@@ -22,7 +22,7 @@ class Notify(pgtrigger.Trigger):
         return ''
 
     def _build_payload(self, model):
-        return  f'''
+        return f'''
             payload := json_build_object(
                 'app', '{model._meta.app_label}',
                 'model', '{model.__name__}',


### PR DESCRIPTION
This fixes #27 and is based on the  https://github.com/Opus10/django-pgpubsub/pull/28 

## Problem
When the model with DateTimeField is deserialized in TriggerChannel the DateTimeField gets string value.

## Reason 
Trigger converts row to json and timestamp is converted to string. The value is taken without any convertion and is passed to the model constructor.

## Solution
Check field type and parse string before invoking django model constructor.

