### PR TITLE
Adds a workaround for the bug in psycopg2

### DIFF
--- a/pgpubsub/tests/test_core.py
+++ b/pgpubsub/tests/test_core.py
@@ -106,9 +106,6 @@ def test_author_bulk_insert_notify(pg_connection):
     with atomic():
         authors = Author.objects.bulk_create(authors)
 
-    # TODO: Understand why pg_connection.poll() is only
-    # necessary when we invoke a notification inside
-    # a transaction (which happens in a bulk_create).
     pg_connection.poll()
     assert 2 == len(pg_connection.notifies)
     assert not Post.objects.exists()

--- a/pgpubsub/tests/test_core.py
+++ b/pgpubsub/tests/test_core.py
@@ -106,6 +106,8 @@ def test_author_bulk_insert_notify(pg_connection):
     with atomic():
         authors = Author.objects.bulk_create(authors)
 
+    # this poll is needed to workaround the bug in psycop2
+    # https://github.com/psycopg/psycopg2/issues/1727
     pg_connection.poll()
     assert 2 == len(pg_connection.notifies)
     assert not Post.objects.exists()


### PR DESCRIPTION
This is a workaround for the bug in psycopg2 described [here](https://github.com/psycopg/psycopg2/issues/1727)

This adds additional polling after the notification processing.