### PR TITLE
Ability to update notification context

### DIFF
--- a/pgpubsub/__init__.py
+++ b/pgpubsub/__init__.py
@@ -1,4 +1,6 @@
-from pgpubsub.channel import Channel, TriggerChannel, set_notification_context
+from pgpubsub.channel import (
+    Channel, TriggerChannel, set_notification_context, update_notification_context
+)
 from pgpubsub.listeners import (
     listener,
     pre_save_listener,

--- a/pgpubsub/channel.py
+++ b/pgpubsub/channel.py
@@ -239,8 +239,8 @@ def _get_notification_context(cursor) -> dict[str, str]:
     return json.loads(val) if val else {}
 
 
-def update_notification_context(
-    mutation: Callable[[Dict[str, Any]], Dict[str, Any]], using: Optional[str] = None
+def _update_notification_context(
+    mutation: Callable[[Callable[[], Dict[str, Any]]], Dict[str, Any]], using: Optional[str] = None
 ) -> None:
     if using:
         conn = connections[using]
@@ -259,7 +259,7 @@ def update_notification_context(
         )
     with conn.cursor() as cursor:
         try:
-            context = mutation(_get_notification_context(cursor))
+            context = mutation(lambda: _get_notification_context(cursor))
             if use_tx_bound_notification_context:
                 scope = 'LOCAL'
             else:
@@ -274,6 +274,17 @@ def update_notification_context(
             else:
                 raise
 
+def update_notification_context(
+    mutator: Callable[[Dict[str, Any]], Dict[str, Any]], using: Optional[str] = None
+) -> None:
+    """
+    update existing notification context by applying mutator function to it
+    """
+    _update_notification_context(
+        lambda existing_context_provider: mutator(existing_context_provider()),
+        using=using,
+    )
+
 
 TX_ABORTED_ERROR_MESSAGE = (
     'current transaction is aborted, commands ignored until end of transaction block'
@@ -282,7 +293,10 @@ TX_ABORTED_ERROR_MESSAGE = (
 def set_notification_context(
     context: Dict[str, Any], using: Optional[str] = None
 ) -> None:
-    update_notification_context(lambda _: context, using=using)
+    """
+    set notification context value
+    """
+    _update_notification_context(lambda _: context, using=using)
 
 
 def locate_channel(channel):

--- a/pgpubsub/channel.py
+++ b/pgpubsub/channel.py
@@ -232,12 +232,15 @@ class TriggerChannel(BaseChannel):
         return model_data
 
 
-TX_ABORTED_ERROR_MESSAGE = (
-    'current transaction is aborted, commands ignored until end of transaction block'
-)
+def _get_notification_context(cursor) -> dict[str, str]:
+    cursor.execute("SELECT current_setting('pgpubsub.notification_context', True)")
+    row = cursor.fetchone()
+    val = row[0]
+    return json.loads(val) if val else {}
 
-def set_notification_context(
-    context: Dict[str, Any], using: Optional[str] = None
+
+def update_notification_context(
+    mutation: Callable[[Dict[str, Any]], Dict[str, Any]], using: Optional[str] = None
 ) -> None:
     if using:
         conn = connections[using]
@@ -256,6 +259,7 @@ def set_notification_context(
         )
     with conn.cursor() as cursor:
         try:
+            context = mutation(_get_notification_context(cursor))
             if use_tx_bound_notification_context:
                 scope = 'LOCAL'
             else:
@@ -269,6 +273,16 @@ def set_notification_context(
                 return
             else:
                 raise
+
+
+TX_ABORTED_ERROR_MESSAGE = (
+    'current transaction is aborted, commands ignored until end of transaction block'
+)
+
+def set_notification_context(
+    context: Dict[str, Any], using: Optional[str] = None
+) -> None:
+    update_notification_context(lambda _: context, using=using)
 
 
 def locate_channel(channel):

--- a/pgpubsub/tests/test_payload_context.py
+++ b/pgpubsub/tests/test_payload_context.py
@@ -46,12 +46,48 @@ def test_notification_context_is_stored_in_payload(
     else:
         settings.PGPUBSUB_TX_BOUND_NOTIFICATION_CONTEXT = tx_bound_context
 
-    pgpubsub.set_notification_context({'test_key': 'test-value'},
-                                        using=db_alias)
+    pgpubsub.set_notification_context({'test_key': 'test-value'}, using=db_alias)
     Media.objects.create(name='avatar.jpg', content_type='image/png', size=15000)
 
     stored_notification = Notification.from_channel(channel=MediaTriggerChannel).get()
     assert stored_notification.payload['context'] == {'test_key': 'test-value'}
+
+    pg_connection.poll()
+    assert 1 == len(pg_connection.notifies)
+
+@pytest.mark.parametrize("db_alias", [None, "default"])
+@pytest.mark.parametrize("tx_bound_context", [None, False])
+@pytest.mark.django_db(transaction=True)
+def test_update_notification_context(
+    pg_connection, settings, db_alias, tx_bound_context, clear_notification_context
+):
+    if tx_bound_context is None:
+        delattr(settings, 'PGPUBSUB_TX_BOUND_NOTIFICATION_CONTEXT')
+    else:
+        settings.PGPUBSUB_TX_BOUND_NOTIFICATION_CONTEXT = tx_bound_context
+    pgpubsub.set_notification_context(
+        {
+            'test_key_kept': 'test-value-kept',
+            'test_key_updated': 'test-value-initial',
+            'test_key_removed': 'test-value-removed',
+        },
+        using=db_alias,
+    )
+
+    pgpubsub.update_notification_context(
+        lambda ctx: (
+            {k:v for k, v in ctx.items() if k != 'test_key_removed'}
+            | {'test_key_updated': 'test-value-updated'}
+        ),
+        using=db_alias,
+    )
+    Media.objects.create(name='avatar.jpg', content_type='image/png', size=15000)
+
+    stored_notification = Notification.from_channel(channel=MediaTriggerChannel).get()
+    assert stored_notification.payload['context'] == {
+        'test_key_kept': 'test-value-kept',
+        'test_key_updated': 'test-value-updated',
+    }
 
     pg_connection.poll()
     assert 1 == len(pg_connection.notifies)

--- a/tox.ini
+++ b/tox.ini
@@ -26,14 +26,14 @@ commands =
     pytest --cov --cov-fail-under=0 --cov-append pgpubsub/ {posargs}
 
 [testenv:report]
-whitelist_externals =
+allowlist_externals =
   poetry
 skip_install = true
 commands =
     coverage report --fail-under 100
 
 [testenv:clean]
-whitelist_externals =
+allowlist_externals =
   poetry
 skip_install = true
 commands = coverage erase


### PR DESCRIPTION
In https://github.com/PaulGilmartin/django-pgpubsub/pull/73 ability to set notification context was added. That implementation had a limitation namely it allowed to override complete context.

In some scenarios it is convenient to update the context partially. One example is when several pieces of infrastructure need to store values in the context and keep values that they did not set.

In this MR the new function `update_notification_context` is added. It gets a mutator function which may be used by clients to examine the current value of the context and update it accordingly.

An alternative implementation would be to change the API so that clients do not update the context as a whole but only set or remove value for a specific key. In this case different clients might update values independently to achive the same result. This however requires some more work specifically to keep the API backward compatible or rather sunset the existing API in favour of the new more flexible API.